### PR TITLE
Implement Filter and ShowAll Commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.commands;
+
+import java.util.function.Predicate;
+
+import seedu.address.model.Model;
+import seedu.address.model.employee.Employee;
+
+/**
+ * Filters the employee list based on the given criteria.
+ */
+public class FilterCommand extends Command {
+    public static final String COMMAND_WORD = "filter";
+    private final Predicate<Employee> predicate;
+    private final String filterDescription;
+
+    /**
+     * Creates a FilterCommand to filter the employee list based on the given criteria.
+     *
+     * @param predicate The predicate to filter the employee list.
+     * @param filterDescription The description of the filter criteria.
+     */
+    public FilterCommand(Predicate<Employee> predicate, String filterDescription) {
+        this.predicate = predicate;
+        this.filterDescription = filterDescription;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        model.updateFilteredEmployeeList(predicate);
+        return new CommandResult("Filtered list based on: " + filterDescription);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ShowAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowAllCommand.java
@@ -1,0 +1,16 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Shows all employees in the employee list to the user.
+ */
+public class ShowAllCommand extends Command {
+    public static final String COMMAND_WORD = "showAll";
+
+    @Override
+    public CommandResult execute(Model model) {
+        model.updateFilteredEmployeeList(employee -> true);
+        return new CommandResult("Showing all employees.");
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,9 +14,11 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ShowAllCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +78,12 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
+
+        case ShowAllCommand.COMMAND_WORD:
+            return new ShowAllCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import java.util.StringJoiner;
+import java.util.function.Predicate;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.employee.Employee;
+import seedu.address.model.employee.Role;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object.
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    @Override
+    public FilterCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_TAG,
+                        CliSyntax.PREFIX_TEAM, CliSyntax.PREFIX_ROLE);
+
+        Predicate<Employee> predicate = employee -> true;
+        StringJoiner filterDescription = new StringJoiner(", ");
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_TAG).isPresent()) {
+            Tag tag = ParserUtil.parseTag(argMultimap.getValue(CliSyntax.PREFIX_TAG).get());
+            predicate = predicate.and(employee -> employee.getTags().contains(tag));
+            filterDescription.add("Tag: " + tag);
+        }
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_TEAM).isPresent()) {
+            String teamName = argMultimap.getValue(CliSyntax.PREFIX_TEAM).get().trim();
+            predicate = predicate.and(employee -> employee.getTeam().toString().equalsIgnoreCase(teamName));
+            filterDescription.add("Team: " + teamName);
+        }
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_ROLE).isPresent()) {
+            Role role = ParserUtil.parseRole(argMultimap.getValue(CliSyntax.PREFIX_ROLE).get());
+            predicate = predicate.and(employee -> employee.getRole().equals(role));
+            filterDescription.add("Role: " + role);
+        }
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_NAME).isPresent()) {
+            String nameString = argMultimap.getValue(CliSyntax.PREFIX_NAME).get().trim();
+            predicate = predicate.and(employee -> employee.getName().fullName.equalsIgnoreCase(nameString));
+            filterDescription.add("Name: " + nameString);
+        }
+
+        return new FilterCommand(predicate, filterDescription.toString());
+    }
+}


### PR DESCRIPTION
The application lacked the ability to filter employees based on attributes like name, team, tag, and role, and there was no command to revert to the unfiltered list of employees.

Filtering is essential for users to efficiently locate specific groups of employees without having to manually search through the entire list.

Implemented the FilterCommand and ShowAllCommand to allow users to filter the employee list by name, team, tag, and role, and to revert to the original unfiltered list respectively.

The filtering logic ignores case and allows spaces in names and teams to improve user experience and match common user expectations.

Let's add the FilterCommandParser to parse user inputs for filtering, enhance the FilterCommand to handle multiple criteria and ignore case, create the ShowAllCommand to reset the filter and show all employees.

This approach improves the application's usability by providing more flexible search capabilities and making
it easier for users to manage and view the employee data.