### PR TITLE
Enhance FilterCommand to Validate Empty Results

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import java.util.function.Predicate;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.employee.Employee;
 
@@ -25,8 +26,13 @@ public class FilterCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         model.updateFilteredEmployeeList(predicate);
+
+        if (model.getFilteredEmployeeList().isEmpty()) {
+            throw new CommandException("No employees found matching the criteria: " + filterDescription);
+        }
+
         return new CommandResult("Filtered list based on: " + filterDescription);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -35,4 +35,12 @@ public class FilterCommand extends Command {
 
         return new CommandResult("Filtered list based on: " + filterDescription);
     }
+
+    /**
+     * Returns the predicate used to filter the employee list.
+     * @return The predicate used to filter the employee list.
+     */
+    public Predicate<Employee> getPredicate() {
+        return predicate;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,5 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TEAM;
+
 import java.util.StringJoiner;
 import java.util.function.Predicate;
 
@@ -16,27 +21,35 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
     @Override
     public FilterCommand parse(String args) throws ParseException {
+        requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_TAG,
-                        CliSyntax.PREFIX_TEAM, CliSyntax.PREFIX_ROLE);
+                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, PREFIX_TAG,
+                        PREFIX_TEAM, PREFIX_ROLE);
+
+        if (!argMultimap.getValue(PREFIX_NAME).isPresent()
+                && !argMultimap.getValue(PREFIX_TAG).isPresent()
+                && !argMultimap.getValue(PREFIX_TEAM).isPresent()
+                && !argMultimap.getValue(PREFIX_ROLE).isPresent()) {
+            throw new ParseException("Invalid arguments for filter command: " + args);
+        }
 
         Predicate<Employee> predicate = employee -> true;
         StringJoiner filterDescription = new StringJoiner(", ");
 
-        if (argMultimap.getValue(CliSyntax.PREFIX_TAG).isPresent()) {
-            Tag tag = ParserUtil.parseTag(argMultimap.getValue(CliSyntax.PREFIX_TAG).get());
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            Tag tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());
             predicate = predicate.and(employee -> employee.getTags().contains(tag));
             filterDescription.add("Tag: " + tag);
         }
 
-        if (argMultimap.getValue(CliSyntax.PREFIX_TEAM).isPresent()) {
-            String teamName = argMultimap.getValue(CliSyntax.PREFIX_TEAM).get().trim();
+        if (argMultimap.getValue(PREFIX_TEAM).isPresent()) {
+            String teamName = argMultimap.getValue(PREFIX_TEAM).get().trim();
             predicate = predicate.and(employee -> employee.getTeam().toString().equalsIgnoreCase(teamName));
             filterDescription.add("Team: " + teamName);
         }
 
-        if (argMultimap.getValue(CliSyntax.PREFIX_ROLE).isPresent()) {
-            Role role = ParserUtil.parseRole(argMultimap.getValue(CliSyntax.PREFIX_ROLE).get());
+        if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
+            Role role = ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
             predicate = predicate.and(employee -> employee.getRole().equals(role));
             filterDescription.add("Role: " + role);
         }
@@ -48,5 +61,11 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
 
         return new FilterCommand(predicate, filterDescription.toString());
+    }
+
+    private void requireNonNull(String args) {
+        if (args == null) {
+            throw new NullPointerException();
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelStub;
+import seedu.address.model.ModelStubWithEmployee;
+import seedu.address.model.ModelStubWithNoEmployee;
+import seedu.address.model.employee.Employee;
+import seedu.address.testutil.EmployeeBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for FilterCommand.
+ */
+public class FilterCommandTest {
+
+    @Test
+    public void execute_validFilter_success() {
+        Employee testEmployee = new EmployeeBuilder().withName("Alice").build();
+        ModelStub modelStub = new ModelStubWithEmployee(testEmployee);
+
+        Predicate<Employee> predicate = employee -> employee.getName().equals(testEmployee.getName());
+        FilterCommand filterCommand = new FilterCommand(predicate, "Name: Alice");
+
+        assertDoesNotThrow(() -> filterCommand.execute(modelStub));
+        assertEquals(Arrays.asList(testEmployee), modelStub.getFilteredEmployeeList());
+    }
+
+    @Test
+    public void execute_invalidFilter_throwsCommandException() {
+        ModelStub modelStub = new ModelStubWithNoEmployee();
+        Predicate<Employee> predicate = employee -> false;
+        FilterCommand filterCommand = new FilterCommand(predicate, "Name: Nonexistent");
+
+        assertThrows(CommandException.class, () -> filterCommand.execute(modelStub));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ShowAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowAllCommandTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalEmployees.getTypicalEmployees;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.ModelStub;
+import seedu.address.model.ModelStubWithFilteredEmployeeList;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ShowAllCommand.
+ */
+public class ShowAllCommandTest {
+
+    @Test
+    public void execute_showAll_success() {
+        ModelStub modelStub = new ModelStubWithFilteredEmployeeList();
+        ShowAllCommand showAllCommand = new ShowAllCommand();
+
+        assertDoesNotThrow(() -> showAllCommand.execute(modelStub));
+        assertEquals(getTypicalEmployees(), modelStub.getFilteredEmployeeList());
+    }
+
+    // Model stubs and other necessary test utilities
+}

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class FilterCommandParserTest {
+
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        assertDoesNotThrow(() -> parser.parse("filter n/ Alice"));
+        assertDoesNotThrow(() -> parser.parse("filter t/ friend"));
+        assertDoesNotThrow(() -> parser.parse("filter T/ Team A"));
+        assertDoesNotThrow(() -> parser.parse("filter r/ Manager"));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(""));
+        assertThrows(ParseException.class, () -> parser.parse("filter"));
+        assertThrows(ParseException.class, () -> parser.parse("filter n/ Alice t/"));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -25,4 +25,10 @@ public class FilterCommandParserTest {
         assertThrows(ParseException.class, () -> parser.parse("filter"));
         assertThrows(ParseException.class, () -> parser.parse("filter n/ Alice t/"));
     }
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        FilterCommandParser parser = new FilterCommandParser();
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
 }

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -1,0 +1,84 @@
+package seedu.address.model;
+
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.employee.Employee;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addEmployee(Employee employee) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasEmployee(Employee employee) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteEmployee(Employee target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setEmployee(Employee target, Employee editedEmployee) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Employee> getFilteredEmployeeList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredEmployeeList(Predicate<Employee> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/model/ModelStubWithEmployee.java
+++ b/src/test/java/seedu/address/model/ModelStubWithEmployee.java
@@ -1,0 +1,46 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.employee.Employee;
+
+/**
+ * A Model stub that contains employees.
+ */
+public class ModelStubWithEmployee extends ModelStub {
+    private final ObservableList<Employee> employees = FXCollections.observableArrayList();
+
+    /**
+     * Initializes a ModelStubWithEmployee with the given employee.
+     * @param employee The employee to be added to the model.
+     */
+    public ModelStubWithEmployee(Employee employee) {
+        requireNonNull(employee);
+        employees.add(employee);
+    }
+
+    @Override
+    public boolean hasEmployee(Employee employee) {
+        requireNonNull(employee);
+        return employees.stream().anyMatch(employee::isSameEmployee);
+    }
+
+    @Override
+    public ObservableList<Employee> getFilteredEmployeeList() {
+        return employees;
+    }
+
+    @Override
+    public void updateFilteredEmployeeList(Predicate<Employee> predicate) {
+        requireNonNull(predicate);
+        ObservableList<Employee> filteredList = employees.stream().filter(predicate)
+                .collect(Collectors.toCollection(FXCollections::observableArrayList));
+        employees.setAll(filteredList);
+    }
+}
+

--- a/src/test/java/seedu/address/model/ModelStubWithFilteredEmployeeList.java
+++ b/src/test/java/seedu/address/model/ModelStubWithFilteredEmployeeList.java
@@ -1,0 +1,40 @@
+package seedu.address.model;
+
+import static seedu.address.testutil.TypicalEmployees.getTypicalEmployees;
+
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.employee.Employee;
+
+/**
+ * A Model stub that contains a filtered list of employees.
+ */
+public class ModelStubWithFilteredEmployeeList extends ModelStub {
+    private ObservableList<Employee> employees = FXCollections.observableArrayList();
+    private ObservableList<Employee> filteredEmployees = FXCollections.observableArrayList();
+
+    /**
+     * Initializes a ModelStubWithFilteredEmployeeList with the given list of employees.
+     */
+    public ModelStubWithFilteredEmployeeList() {
+        employees.addAll(getTypicalEmployees());
+        filteredEmployees.addAll(employees);
+    }
+
+    @Override
+    public ObservableList<Employee> getFilteredEmployeeList() {
+        return filteredEmployees;
+    }
+
+    @Override
+    public void updateFilteredEmployeeList(Predicate<Employee> predicate) {
+        filteredEmployees = employees.stream().filter(predicate).collect(Collectors
+                .toCollection(FXCollections::observableArrayList));
+    }
+    public void resetData() {
+        filteredEmployees = FXCollections.observableArrayList(employees);
+    }
+}

--- a/src/test/java/seedu/address/model/ModelStubWithNoEmployee.java
+++ b/src/test/java/seedu/address/model/ModelStubWithNoEmployee.java
@@ -1,0 +1,33 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.employee.Employee;
+
+/**
+ * A Model stub that contains no employees.
+ */
+public class ModelStubWithNoEmployee extends ModelStub {
+    private final ObservableList<Employee> employees = FXCollections.observableArrayList();
+
+    @Override
+    public boolean hasEmployee(Employee employee) {
+        requireNonNull(employee);
+        return false;
+    }
+
+    @Override
+    public ObservableList<Employee> getFilteredEmployeeList() {
+        return employees;
+    }
+
+    @Override
+    public void updateFilteredEmployeeList(Predicate<Employee> predicate) {
+        // The list remains empty because there are no employees to filter.
+    }
+}
+


### PR DESCRIPTION
Previously, the FilterCommand did not validate the result of the applied filter, potentially leading to an empty result set without notifying the user.

To improve user feedback and command robustness, the FilterCommand now throws a CommandException if the filter criteria result in an empty list of employees. This change ensures that users are explicitly informed when no employees match the specified filter criteria, enhancing the command's usability and user experience.

Additionally, updated the FilterCommandParserTest to handle scenarios where invalid arguments are provided. This ensures that the command parser correctly throws ParseExceptions when expected, enhancing the reliability of the command parsing process.

These changes enhance the application's feedback mechanism and ensure consistent behavior across command executions, improving the overall user experience.