### PR TITLE
Improve DeleteCommandParser code quality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -136,7 +136,6 @@ public class DeleteCommand extends Command {
 
     /**
      * Deletes an employee by unique id
-     * TODO: Implement the functionality to delete by ID using this function
      *
      * @param model the model to execute the command
      * @return the result of the command

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -155,17 +155,27 @@ public class DeleteCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
+        if (this == other) {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof DeleteCommand)) {
             return false;
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+
+        // Check if both commands have the same index
+        boolean isIndexEqual = targetIndex != null
+                && otherDeleteCommand.targetIndex != null
+                && targetIndex.equals(otherDeleteCommand.targetIndex);
+
+        // Check if both commands have the same UID
+        boolean isUidEqual = uid != null
+                && otherDeleteCommand.uid != null
+                && uid.equals(otherDeleteCommand.uid);
+
+        return isIndexEqual || isUidEqual;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
@@ -18,28 +19,40 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        // Check if "uid" is part of the arguments and parse accordingly
+        if (trimmedArgs.startsWith("uid/")) {
+            return parseDeleteByUniqueId(trimmedArgs);
+        }
+
         try {
-            Index index = ParserUtil.parseIndex(args);
+            Index index = ParserUtil.parseIndex(trimmedArgs);
             return new DeleteCommand(index);
         } catch (ParseException pe) {
-            String trimmedArgs = args.trim();
-            if (trimmedArgs.isEmpty()) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
-            // check if "uid" is in the args, if so, parse it as a UniqueId
-            if (trimmedArgs.contains("uid")) {
-                // the args are in the format "uid/<uid>"
-                String[] splitArgs = trimmedArgs.split("/");
-                if (splitArgs.length != 2) {
-                    throw new ParseException(
-                            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-                }
-                UniqueId uid = new UniqueId(splitArgs[1]);
-                return new DeleteCommand(uid);
-            }
-            return new DeleteCommand(trimmedArgs);
+            // If parsing the index fails, rethrow the exception with a message specific to DeleteCommand
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * @param args Arguments to be parsed
+     * @return DeleteCommand object for execution
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private DeleteCommand parseDeleteByUniqueId(String args) throws ParseException {
+        String[] splitArgs = args.split("/", 2);
+        if (splitArgs.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+        UniqueId uid = new UniqueId(splitArgs[1]);
+        return new DeleteCommand(uid);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -49,7 +49,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     private DeleteCommand parseDeleteByUniqueId(String args) throws ParseException {
         String[] splitArgs = args.split("/", 2);
-        if (splitArgs.length != 2) {
+        if (splitArgs.length != 2 || splitArgs[1].isEmpty() || !splitArgs[1].matches("[0-9]+")) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
         UniqueId uid = new UniqueId(splitArgs[1]);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.parser.DeleteCommandParser;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -149,7 +150,7 @@ public class DeleteCommandTest {
         String invalidUid = "uid/non_existent";
         DeleteCommandParser parser = new DeleteCommandParser();
 
-        assertThrows(NumberFormatException.class, () -> parser.parse(invalidUid));
+        assertThrows(ParseException.class, () -> parser.parse(invalidUid));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showEmployeeAtIndex;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEmployees.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_EMPLOYEE;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
+import seedu.address.logic.parser.DeleteCommandParser;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -140,6 +142,14 @@ public class DeleteCommandTest {
 
         // different employee -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @Test
+    public void execute_invalidUidUnfilteredList_throwsParseException() {
+        String invalidUid = "uid/non_existent";
+        DeleteCommandParser parser = new DeleteCommandParser();
+
+        assertThrows(NumberFormatException.class, () -> parser.parse(invalidUid));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -9,6 +10,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.employee.UniqueId;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -38,11 +41,43 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidUidFormat_throwsNullPointerException() {
-        assertThrows(NumberFormatException.class, () -> parser.parse("uid/"));
+        assertThrows(ParseException.class, () -> parser.parse("uid/"));
     }
 
     @Test
     public void parse_missingUid_throwsParseException() {
         assertParseFailure(parser, "uid", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_validUid_returnsDeleteCommand() {
+        String validUid = "12345";
+        UniqueId uid = new UniqueId(validUid);
+        DeleteCommand expectedCommand = new DeleteCommand(uid);
+
+        assertNotNull(expectedCommand);
+        assertParseSuccess(parser, "uid/" + validUid, expectedCommand);
+    }
+
+
+    @Test
+    public void parse_invalidUid_throwsParseException() {
+        String invalidUid = "invalid";
+        assertParseFailure(parser, "uid/" + invalidUid, String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_missingUidPart_throwsParseException() {
+        assertParseFailure(parser, "uid/", String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_uidWithExtraSlash_throwsParseException() {
+        String uidWithExtraSlash = "12345/";
+        assertParseFailure(parser, "uid/" + uidWithExtraSlash, String
+                .format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 
 import org.junit.jupiter.api.Test;
@@ -9,7 +12,7 @@ import seedu.address.logic.commands.DeleteCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * outside the DeleteCommand code. For example, inputs "1" and "1 abc" take the
  * same path through the DeleteCommand, and therefore we test only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
@@ -21,5 +24,25 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_EMPLOYEE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidUidFormat_throwsNullPointerException() {
+        assertThrows(NumberFormatException.class, () -> parser.parse("uid/"));
+    }
+
+    @Test
+    public void parse_missingUid_throwsParseException() {
+        assertParseFailure(parser, "uid", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Removed non-exception handling code from the catch block in DeleteCommandParser to adhere to best coding practices. This change improves the code quality by ensuring that the catch block is used solely for handling parsing exceptions and not for processing business logic. This refactor enhances the maintainability and readability of the code, making it easier to understand and manage.