### PR TITLE
Fix FilterCommand functionality in ContactSwift

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TEAM;
 
+import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Predicate;
 
@@ -23,27 +24,39 @@ public class FilterCommandParser implements Parser<FilterCommand> {
     public FilterCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, PREFIX_TAG,
-                        PREFIX_TEAM, PREFIX_ROLE);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TAG, PREFIX_TEAM, PREFIX_ROLE);
+
+        if (argMultimap.getAllValues(PREFIX_NAME).size() > 1) {
+            throw new ParseException("Multiple name values are not allowed.");
+        }
+        if (argMultimap.getAllValues(PREFIX_ROLE).size() > 1) {
+            throw new ParseException("Multiple role values are not allowed.");
+        }
+        if (argMultimap.getAllValues(PREFIX_TEAM).size() > 1) {
+            throw new ParseException("Multiple team values are not allowed.");
+        }
 
         if (!argMultimap.getValue(PREFIX_NAME).isPresent()
-                && !argMultimap.getValue(PREFIX_TAG).isPresent()
+                && argMultimap.getAllValues(PREFIX_TAG).isEmpty()
                 && !argMultimap.getValue(PREFIX_TEAM).isPresent()
                 && !argMultimap.getValue(PREFIX_ROLE).isPresent()) {
             throw new ParseException("Invalid arguments for filter command: " + args);
         }
 
         Predicate<Employee> predicate = employee -> true;
-        StringJoiner filterDescription = new StringJoiner(", ");
+        StringJoiner filterDescription = new StringJoiner("and ");
 
-        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            Tag tag = ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());
-            predicate = predicate.and(employee -> employee.getTags().contains(tag));
-            filterDescription.add("Tag: " + tag);
+        List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
+        if (!tags.isEmpty()) {
+            for (String tagValue : tags) {
+                Tag tag = ParserUtil.parseTag(tagValue);
+                predicate = predicate.and(employee -> employee.getTags().contains(tag));
+                filterDescription.add("Tag: " + tag);
+            }
         }
 
         if (argMultimap.getValue(PREFIX_TEAM).isPresent()) {
-            String teamName = argMultimap.getValue(PREFIX_TEAM).get().trim();
+            String teamName = "Team " + argMultimap.getValue(PREFIX_TEAM).get().trim();
             predicate = predicate.and(employee -> employee.getTeam().toString().equalsIgnoreCase(teamName));
             filterDescription.add("Team: " + teamName);
         }
@@ -54,8 +67,8 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             filterDescription.add("Role: " + role);
         }
 
-        if (argMultimap.getValue(CliSyntax.PREFIX_NAME).isPresent()) {
-            String nameString = argMultimap.getValue(CliSyntax.PREFIX_NAME).get().trim();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String nameString = argMultimap.getValue(PREFIX_NAME).get().trim();
             predicate = predicate.and(employee -> employee.getName().fullName.equalsIgnoreCase(nameString));
             filterDescription.add("Name: " + nameString);
         }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -15,7 +15,7 @@ public class FilterCommandParserTest {
     public void parse_validArgs_returnsFilterCommand() {
         assertDoesNotThrow(() -> parser.parse("filter n/ Alice"));
         assertDoesNotThrow(() -> parser.parse("filter t/ friend"));
-        assertDoesNotThrow(() -> parser.parse("filter T/ Team A"));
+        assertDoesNotThrow(() -> parser.parse("filter T/ A"));
         assertDoesNotThrow(() -> parser.parse("filter r/ Manager"));
     }
 
@@ -30,5 +30,26 @@ public class FilterCommandParserTest {
     public void parse_nullArgs_throwsNullPointerException() {
         FilterCommandParser parser = new FilterCommandParser();
         assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    public void parse_multipleNames_throwsParseException() {
+        FilterCommandParser parser = new FilterCommandParser();
+        String input = "filter n/Alice n/Bob";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_multipleRoles_throwsParseException() {
+        FilterCommandParser parser = new FilterCommandParser();
+        String input = "filter r/Manager r/Developer";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_multipleTeams_throwsParseException() {
+        FilterCommandParser parser = new FilterCommandParser();
+        String input = "filter T/Marketing T/Sales";
+        assertThrows(ParseException.class, () -> parser.parse(input));
     }
 }


### PR DESCRIPTION
Refined the FilterCommand parsing logic to correctly support multiple tags. Updated the parsing mechanism to strictly enforce single-value constraints for name, role, and team fields, preventing ambiguity in filter conditions. These improvements ensure precise and targeted employee searches, enhancing the usability and functionality of ContactSwift's filtering capabilities. This commit aligns with our goal to provide clear, effective, and intuitive features for managing employee data within the application.