### PR TITLE
Enhance EmployeeListCard UI by repositioning uid label

### DIFF
--- a/src/main/resources/view/EmployeeListCard.fxml
+++ b/src/main/resources/view/EmployeeListCard.fxml
@@ -19,6 +19,7 @@
       <padding>
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
+      <Label fx:id="uid" styleClass="cell_small_label" text="\$uid" />
          <Label fx:id="teamRole" styleClass="cell_small_label" text="\$teamRole" />
       <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
@@ -28,7 +29,6 @@
           </minWidth>
         </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
-        <Label fx:id="uid" styleClass="cell_small_label" text="\$uid" />
         <Label fx:id="completionRate" styleClass="cell_small_label" text="\$productivity"/>
       </HBox>
       <FlowPane fx:id="tags" />


### PR DESCRIPTION
This commit introduces a significant improvement to the user interface of the EmployeeListCard. The 'uid' label, which represents the unique identifier of an employee, has been repositioned to the top of the card. This change enhances the visibility and accessibility of the 'uid' information, making it immediately apparent to users upon viewing an employee card.

In addition to improving user experience, this change also aligns with common design practices where unique identifiers are typically displayed at the top of information cards. This ensures consistency across the application's UI and enhances overall usability.

Overall, these changes contribute to a more intuitive and information-rich user interface, enhancing the application's usability and user satisfaction.