### PR TITLE
Add duplicate UID check in JSON

### DIFF
--- a/src/main/java/seedu/address/model/employee/UniqueId.java
+++ b/src/main/java/seedu/address/model/employee/UniqueId.java
@@ -7,6 +7,8 @@ import seedu.address.commons.exceptions.IllegalValueException;
  * Todo: Add validation for uid
  */
 public class UniqueId {
+    public static final Integer DEFAULT_BASE_UID = 100;
+
     private static final String VALIDATION_REGEX = "\\d+";
 
     private static Integer lastUsedIndex;

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -20,6 +20,14 @@ import seedu.address.model.employee.UniqueId;
  */
 public class JsonAddressBookStorage implements AddressBookStorage {
 
+    private static final String ERROR_DUPLICATE_UIDS = "Duplicate UIDs found in data. "
+            + "Starting with template data instead.";
+    private static final String DUPLICATE_UID_WARNING = "\n============================================"
+            + "============================================\n"
+            + ERROR_DUPLICATE_UIDS
+            + "\n============================================"
+            + "============================================";
+
     private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
 
     private Path filePath;
@@ -55,6 +63,10 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         try {
             JsonSerializableAddressBook addressBook = jsonAddressBook.get();
             Integer maxUid = addressBook.getMaxUid();
+            if (addressBook.hasDuplicateUids()) {
+                logger.warning(DUPLICATE_UID_WARNING);
+                return Optional.empty();
+            }
             UniqueId.setLastUsedIndex(maxUid);
             return Optional.of(jsonAddressBook.get().toModelType());
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -1,5 +1,7 @@
 package seedu.address.storage;
 
+import static seedu.address.model.employee.UniqueId.DEFAULT_BASE_UID;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -62,6 +64,20 @@ class JsonSerializableAddressBook {
         return employees.stream()
                 .mapToInt(JsonAdaptedEmployee::getUid)
                 .max()
-                .orElse(0); // returns 0 if list is empty
+                .orElse(DEFAULT_BASE_UID); // returns 0 if list is empty
+    }
+
+    /**
+     * Method to check if duplicate UIDs are present in the list of employees
+     * if duplicate UIDs are present, return true
+     * else return false
+     *
+     * @return true if duplicate UIDs are present, else false
+     */
+    public boolean hasDuplicateUids() {
+        List<Integer> uids = employees.stream()
+                .map(JsonAdaptedEmployee::getUid)
+                .collect(Collectors.toList());
+        return uids.size() != uids.stream().distinct().count();
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -64,7 +64,7 @@ class JsonSerializableAddressBook {
         return employees.stream()
                 .mapToInt(JsonAdaptedEmployee::getUid)
                 .max()
-                .orElse(DEFAULT_BASE_UID); // returns 0 if list is empty
+                .orElse(DEFAULT_BASE_UID); // returns default base id if list if empty
     }
 
     /**


### PR DESCRIPTION
This commit introduces a new feature where the system checks for duplicate UIDs in the JSON file. If duplicates are found, the system starts with the default template.

This is to ensure data integrity and prevent potential issues caused by duplicate UIDs. This feature is crucial for maintaining the uniqueness of UIDs in our system.

It prevents the system from processing the same UID twice, which could lead to unexpected behavior or errors.

By starting with the default template when duplicates are found, we ensure that the system can continue to function normally while the user investigates the source of the duplicate UIDs.